### PR TITLE
remove abbr underline on forms required asterisk

### DIFF
--- a/sass/global/_shame.scss
+++ b/sass/global/_shame.scss
@@ -1,0 +1,4 @@
+// remove the forms required asterisk abbr underline
+abbr.required {
+	text-decoration: none;
+}


### PR DESCRIPTION
This PR removes the abbreviation underline for the required asterisk used on forms. 
Before: 
![screen shot 2017-05-15 at 4 23 14 pm](https://cloud.githubusercontent.com/assets/4327102/26077662/d627f1fe-398a-11e7-90dc-ed18b15f408a.png)

After: 
![screen shot 2017-05-15 at 4 36 10 pm](https://cloud.githubusercontent.com/assets/4327102/26078169/a2c36c10-398c-11e7-90c2-b29de124bccb.png)
